### PR TITLE
feat(Slack): link to activity info when displaying class name

### DIFF
--- a/config.template.yaml
+++ b/config.template.yaml
@@ -14,6 +14,7 @@ cron:
   python_path: "<path to python>" # e.g. "venv/bin"
   log_path: "/var/log/sit_rezervo.log"
 # notifications:
+#   host: "https://sit-rezervo.example.org"
 #   reminder_hours_before: 4
 #   transfersh:
 #    url: "<transfer.sh instance url>"

--- a/sit_rezervo/config.py
+++ b/sit_rezervo/config.py
@@ -43,6 +43,7 @@ class Slack:
 
 @dataclass
 class Notifications:
+    host: Optional[str] = None
     transfersh: Optional[Transfersh] = None
     slack: Optional[Slack] = None
     reminder_hours_before: Optional[int] = None

--- a/sit_rezervo/notify/notify.py
+++ b/sit_rezervo/notify/notify.py
@@ -35,14 +35,15 @@ def notify_booking(notifications_config: Notifications, booked_class: Dict[str, 
             transfersh_url = notifications_config.transfersh.url
         else:
             transfersh_url = None
-        return notify_booking_slack(slack_config.bot_token, slack_config.channel_id, slack_config.user_id, booked_class,
-                                    ical_url, transfersh_url, scheduled_reminder_id)
+        return notify_booking_slack(slack_config.bot_token, slack_config.channel_id, slack_config.user_id,
+                                    notifications_config.host, booked_class, ical_url, transfersh_url,
+                                    scheduled_reminder_id)
     print("[WARNING] No notification targets, booking notification will not be sent!")
 
 
 def schedule_class_reminder(notifications_config: Notifications, booked_class: Dict[str, Any]) -> Optional[str]:
     slack_config = notifications_config.slack
     if slack_config is not None:
-        return schedule_class_reminder_slack(slack_config.bot_token, slack_config.user_id,
+        return schedule_class_reminder_slack(slack_config.bot_token, slack_config.user_id, notifications_config.host,
                                              booked_class, notifications_config.reminder_hours_before)
     print("[WARNING] No notification targets, class reminder will not be sent!")

--- a/sit_rezervo/notify/slack.py
+++ b/sit_rezervo/notify/slack.py
@@ -11,7 +11,7 @@ from ..auth import AuthenticationError
 from ..config import Class
 from ..consts import WEEKDAYS, SLACK_ACTION_ADD_BOOKING_TO_CALENDAR, SLACK_ACTION_CANCEL_BOOKING
 from ..errors import BookingError
-from .utils import upload_ical_to_transfersh
+from .utils import upload_ical_to_transfersh, activity_url
 
 
 def notify_slack(slack_token: str, channel: str, message: str, message_blocks: Optional[List[Dict[str, Any]]] = None,
@@ -90,7 +90,7 @@ def schedule_class_reminder_slack(slack_token: str, user_id: str, _class: Dict[s
     start_time = datetime.datetime.fromisoformat(_class['from'])
     reminder_time = start_time - datetime.timedelta(hours=hours_before)
     reminder_timestamp = int(time.mktime(reminder_time.timetuple()))
-    message = f"Husk *{_class['name']}* ({_class['from']}) om {hours_before} timer!"
+    message = f"Husk *{activity_url(_class)}* ({_class['from']}) om {hours_before} timer!"
     return schedule_dm_slack(slack_token, user_id, reminder_timestamp, message)
 
 
@@ -307,7 +307,7 @@ def build_booking_message_blocks(booked_class: Dict[str, Any], user_id: str, ica
                 },
                 "text": {
                     "type": "plain_text",
-                    "text": f"Du er i ferd med å avbestille {booked_class['name']} ({booked_class['from']}). "
+                    "text": f"Du er i ferd med å avbestille {activity_url(booked_class)} ({booked_class['from']}). "
                             f"Dette kan ikke angres!"
                 },
                 "confirm": {
@@ -332,7 +332,7 @@ def build_booking_message_blocks(booked_class: Dict[str, Any], user_id: str, ica
             },
             "url": ical_tsh_url
         })
-    message = f"{BOOKING_EMOJI} *{booked_class['name']}* ({booked_class['from']}) er booket for <@{user_id}>"
+    message = f"{BOOKING_EMOJI} {activity_url(booked_class)} ({booked_class['from']}) er booket for <@{user_id}>"
     blocks = [
         {
             "type": "section",

--- a/sit_rezervo/notify/utils.py
+++ b/sit_rezervo/notify/utils.py
@@ -1,3 +1,5 @@
+from typing import Dict, Any
+
 from urllib.parse import urlparse
 
 import requests
@@ -11,3 +13,6 @@ def transfersh_direct_url(url: str):
     # prepend '/get' to the url path
     u = urlparse(url.strip())
     return u._replace(path=f"/get{u.path}").geturl()
+
+def activity_url(_class: Dict[str, Any]):
+    return f"<https://sit.biku.be/?activityId={_class['activityId']}|*{_class['name']}*>"

--- a/sit_rezervo/notify/utils.py
+++ b/sit_rezervo/notify/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from urllib.parse import urlparse
 
@@ -14,5 +14,9 @@ def transfersh_direct_url(url: str):
     u = urlparse(url.strip())
     return u._replace(path=f"/get{u.path}").geturl()
 
-def activity_url(_class: Dict[str, Any]):
-    return f"<https://sit.biku.be/?activityId={_class['activityId']}|*{_class['name']}*>"
+
+def activity_url(host: Optional[str], _class: Dict[str, Any]):
+    if host:
+        return f"<{host}/?classId={_class['id']}|*{_class['name']}*>"
+
+    return f"*{_class['name']}*"


### PR DESCRIPTION
With this change, every time a class is referenced in a Slack message, it is wrapped in a link to the sit.biku.be info page for that class.

 Depends on https://github.com/mathiazom/sit-rezervo-confgen/pull/14