### PR TITLE
build: Bump Postgres to v18 due to v14 EOL

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,11 +1,11 @@
 name: "rezervo"
 services:
   db:
-    image: postgres:14.5
+    image: postgres:18
     container_name: rezervo-db
     restart: unless-stopped
     volumes:
-      - rezervo-data:/var/lib/postgresql/data
+      - rezervo-data:/var/lib/postgresql
     ports:
       - 5432:5432
     environment:

--- a/docker/docker-compose.template.yml
+++ b/docker/docker-compose.template.yml
@@ -2,10 +2,10 @@ name: "rezervo"
 services:
   db:
     container_name: rezervo-db
-    image: postgres:14.5
+    image: postgres:18
     restart: unless-stopped
     volumes:
-      - rezervo-data:/var/lib/postgresql/data
+      - rezervo-data:/var/lib/postgresql
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 5s


### PR DESCRIPTION
Postgres 14 has end of life in November 26', we really should upgrade for security and performance.

To update the live database the easiest thing is probably to dump the data from v14 and then restore into a newly created v18 image. See  https://github.com/docker-library/postgres/issues/37 if you want a (long) explanation and some Postgres lore 🫠 